### PR TITLE
Bump version to `0.2.0-beta01`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ android.nonTransitiveRClass=true
 publish.groupId=com.justeattakeaway
 publish.artifactId=interval-annotated-string
 
-publish.versionName=0.2.0-alpha01
+publish.versionName=0.2.0-beta01
 
 publish.pom.name=Interval Annotated String
 publish.pom.description=This small Android utility library makes it easy to create and manage embedded links and styles within localized text.


### PR DESCRIPTION
It seems it is time to bump to `0.2.0-beta01` as alpha version was in release for 3 weeks already.